### PR TITLE
Remove unused dependencies

### DIFF
--- a/registry-api/pom.xml
+++ b/registry-api/pom.xml
@@ -33,16 +33,66 @@
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
             <version>4.2.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jul-to-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-model-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>javax.el</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.mifmif</groupId>
+                    <artifactId>generex</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>dubbo-registry-api</artifactId>
             <version>2.6.7</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.alibaba</groupId>
+                    <artifactId>dubbo-serialization-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>de.javakaffee</groupId>
+                    <artifactId>kryo-serializers</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>23.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+            </exclusions> 
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
@htynkn Hi, I am a user of project **_com.alibaba.dubbo:kubernetes-registry-api:1.0.0-SNAPSHOT_**. I found that its pom file introduced **_45_** dependencies. However, among them, **_12_** libraries (**_26%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_com.alibaba.dubbo:kubernetes-registry-api:1.0.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.slf4j:jul-to-slf4j:jar:1.7.26:compile
io.fabric8:kubernetes-model-common:jar:4.2.0:compile
com.google.code.findbugs:jsr305:jar:1.3.9:compile
com.google.j2objc:j2objc-annotations:jar:1.1:compile
org.codehaus.mojo:animal-sniffer-annotations:jar:1.14:compile
dk.brics.automaton:automaton:jar:1.11-8:compile
javax.validation:validation-api:jar:2.0.1.Final:compile
com.google.errorprone:error_prone_annotations:jar:2.0.18:compile
com.alibaba:dubbo-serialization-api:jar:2.6.7:compile
com.github.mifmif:generex:jar:1.0.2:compile
de.javakaffee:kryo-serializers:jar:0.42:compile
org.glassfish:javax.el:jar:3.0.1-b11:compile
</code></pre>
