### PR TITLE
refactor(ci): bump actions and remove explicit cache steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        id: go
-      - uses: actions/checkout@v3
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -42,29 +43,17 @@ jobs:
     name: Go Test
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        id: go
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/setup-go@v4
         with:
-          fetch-depth: 0
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          # Cache
-          path: ~/go/pkg/mod
-          # Cache key
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          # An ordered list of keys to use for restoring the cache if no cache hit occurred for key
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Get dependencies
+          go-version-file: go.mod
+      - name: Download dependencies
         run: |
-          go get -v -t -d ./...
+          go mod download
       - name: Go Test
         run: |
-          go mod vendor && go test ./... -gcflags=-l -coverprofile=coverage.txt -covermode=atomic
+          go test ./... -gcflags=-l -coverprofile=coverage.txt -covermode=atomic
       - name: "Upload test result"
         if: always()
         uses: actions/upload-artifact@v3
@@ -78,12 +67,11 @@ jobs:
     name: License Check - Go
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
 
       - name: Check License Header
         uses: apache/skywalking-eyes/header@main
@@ -92,24 +80,14 @@ jobs:
     name: Go fmt
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        id: go
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-      - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/setup-go@v4
         with:
-          # Cache
-          path: ~/go/pkg/mod
-          # Cache key
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          # An ordered list of keys to use for restoring the cache if no cache hit occurred for key
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Get dependencies
+          go-version-file: go.mod
+      - name: Download dependencies
         run: |
-          go get -v -t -d ./...
+          go mod download
       - name: Go Fmt
         run: |
           go fmt ./... && git status && [[ -z `git status -s` ]]


### PR DESCRIPTION
## What is the purpose of the change

refactor the ci test workflow, as the actions and steps may out of date.

## Brief changelog

- remove explicit cache steps, as the new version of `setup-go` tries to enable caching unless the cache input is explicitly set to false (https://github.com/actions/setup-go/tree/main#v4)
- setup go with the version set in go.mod, [the feature is supported by setup-go](https://github.com/actions/setup-go/tree/main#getting-go-version-from-the-gomod-file)
- Use `go mod download` to download go modules given in [go.mod](https://go.dev/ref/mod#glos-main-module) into go caches (https://go.dev/ref/mod#go-mod-download).
