### PR TITLE
only print usage string when occurring flag error (#32)

### DIFF
--- a/app/dubboctl/cmd/root.go
+++ b/app/dubboctl/cmd/root.go
@@ -34,15 +34,25 @@ type RootCommandConfig struct {
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute(args []string) {
 	rootCmd := getRootCmd(args)
+	// when flag error occurs, print usage string.
+	// but if an error occurs when executing command, usage string will not be printed.
+	rootCmd.SetFlagErrorFunc(func(command *cobra.Command, err error) error {
+		command.Println(command.UsageString())
+
+		return err
+	})
+
 	cobra.CheckErr(rootCmd.Execute())
 }
 
 func getRootCmd(args []string) *cobra.Command {
 	// rootCmd represents the base command when called without any subcommands
 	rootCmd := &cobra.Command{
-		Use:   "dubboctl",
-		Short: "dubbo control interface",
-		Long:  ``,
+		Use:           "dubboctl",
+		Short:         "dubbo control interface",
+		Long:          ``,
+		SilenceErrors: true,
+		SilenceUsage:  true,
 	}
 
 	cfg := RootCommandConfig{


### PR DESCRIPTION
## What is the purpose of the change

#32 is resolved. Now, only print usage string when occurring flag error. But if an error occurs when executing command, usage string will not be printed.

