### PR TITLE
Add Dubbo-Kubernetes Release workflow

### DIFF
--- a/.github/workflows/dubbo-cp-image.yaml
+++ b/.github/workflows/dubbo-cp-image.yaml
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Dubbo ctl Release
+
+on:
+  release:
+    types: [create, published]
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    name: Release Dubbo
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.release.tag_name, 'dubbo/')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Docker
+        uses: docker-practice/actions-setup-docker@v1
+
+      - name: Build and push dubbo-cp image
+        env:
+          GIT_VERSION: ${GITHUB_REF#refs/tags/dubbo/}
+          REGISTRY_USER_NAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          make image-dubbocp
+          make push-image-dubbocp

--- a/.github/workflows/dubbo-release.yaml
+++ b/.github/workflows/dubbo-release.yaml
@@ -1,0 +1,89 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Dubbo ctl Release
+
+on:
+  release:
+    types: [create, published]
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    name: Release Dubbo
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.release.tag_name, 'dubbo/')
+    strategy:
+      matrix:
+        goos: [linux, darwin, windows]
+        goarch: [386, amd64, arm64]
+        exclude:
+          - goos: darwin
+            goarch: 386
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
+      - name: Download dependencies
+        run: |
+          go mod download
+
+      - name: Prepare build directory
+        run: |
+          mkdir -p build/
+          cp README.md build/
+          cp LICENSE build/
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          make build-dubboctl
+          make build-dubbocp
+          cp -r conf build/conf
+          mv bin/dubboctl build/dubboctl
+          mv bin/dubbo-cp build/dubbo-cp
+      - name: Rename on windows
+        if: matrix.goos == 'windows'
+        run: |
+          mv build/dubboctl build/dubboctl.exe
+          mv build/dubbo-cp build/dubbo-cp.exe
+
+      - name: Create package
+        id: package
+        run: |
+          PACKAGE_NAME=dubbo-${GITHUB_REF#refs/tags/dubbo/}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+          tar -czvf $PACKAGE_NAME -C build .
+          echo "name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Upload asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./${{ steps.package.outputs.name }}
+          asset_name: ${{ steps.package.outputs.name }}
+          asset_content_type: application/gzip

--- a/.github/workflows/dubboctl-release.yaml
+++ b/.github/workflows/dubboctl-release.yaml
@@ -1,0 +1,85 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Dubbo ctl Release
+
+on:
+  release:
+    types: [create, published]
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    name: Release Dubboctl
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.release.tag_name, 'dubboctl/')
+    strategy:
+      matrix:
+        goos: [linux, darwin, windows]
+        goarch: [386, amd64, arm64]
+        exclude:
+          - goos: darwin
+            goarch: 386
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
+      - name: Download dependencies
+        run: |
+          go mod download
+
+      - name: Prepare build directory
+        run: |
+          mkdir -p build/
+          cp README.md build/
+          cp LICENSE build/
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          make build-dubboctl
+          mv bin/dubboctl build/dubboctl
+      - name: Rename on windows
+        if: matrix.goos == 'windows'
+        run: |
+          mv build/dubboctl build/dubboctl.exe
+
+      - name: Create package
+        id: package
+        run: |
+          PACKAGE_NAME=dubboctl-${GITHUB_REF#refs/tags/dubboctl/}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+          tar -czvf $PACKAGE_NAME -C build .
+          echo "name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Upload asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./${{ steps.package.outputs.name }}
+          asset_name: ${{ steps.package.outputs.name }}
+          asset_content_type: application/gzip

--- a/release/downloadDubbo.sh
+++ b/release/downloadDubbo.sh
@@ -26,7 +26,7 @@ fi
 # Determine the latest Dubbo version by version number ignoring alpha, beta, and rc versions.
 if [ "${DUBBO_VERSION}" = "" ] ; then
   DUBBO_VERSION="$(curl -sL https://github.com/dawnzzz/dubbo-kubernetes/releases | \
-                  grep -E -o 'dubboctl/([v,V]?)[0-9]*.[0-9]*.[0-9]*' | sort -V | \
+                  grep -E -o 'dubbo/([v,V]?)[0-9]*.[0-9]*.[0-9]*' | sort -V | \
                   tail -1 | awk -F'/' '{ print $2}')"
   DUBBO_VERSION="${DUBBO_VERSION##*/}"
 fi
@@ -66,7 +66,7 @@ download_failed () {
 tmp=$(mktemp -d /tmp/dubboctl.XXXXXX)
 NAME="dubboctl-${DUBBO_VERSION}"
 
-ARCH_URL="https://github.com/apache/dubbo-kubernetes/releases/download/dubboctl%2F${DUBBO_VERSION}/dubboctl-${DUBBO_VERSION}-${OSEXT}-${DUBBO_ARCH}.tar.gz"
+ARCH_URL="https://github.com/apache/dubbo-kubernetes/releases/download/dubbo%2F${DUBBO_VERSION}/dubbo-${DUBBO_VERSION}-${OSEXT}-${DUBBO_ARCH}.tar.gz"
 
 with_arch() {
   printf "\nDownloading %s from %s ...\n" "${NAME}" "$ARCH_URL"


### PR DESCRIPTION
add dubbo-kubernetes release workflow:
1. release dubboclt with tag "dubboctl/xxx"
2. release dubbo (including dubboctl and dubbo-cp) with tag "dubbo/xxx" and push the dubbo-cp image.
3. offer download scripts
