### PR TITLE
ci: only run the tests in upstream with main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,17 @@ name: Continues Integration
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
 
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+    if: github.repository == 'apache/dubbo-kubernetes'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go 1.x
@@ -42,6 +47,7 @@ jobs:
   unit-test:
     name: Go Test
     runs-on: ubuntu-latest
+    if: github.repository == 'apache/dubbo-kubernetes'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go 1.x
@@ -66,6 +72,7 @@ jobs:
   license-check:
     name: License Check - Go
     runs-on: ubuntu-latest
+    if: github.repository == 'apache/dubbo-kubernetes'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go 1.x
@@ -79,6 +86,7 @@ jobs:
   go-fmt:
     name: Go fmt
     runs-on: ubuntu-latest
+    if: github.repository == 'apache/dubbo-kubernetes'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go 1.x


### PR DESCRIPTION
## What is the purpose of the change

Skip the CI tests in downstream repos by adding the [`if` conditions](https://docs.github.com/actions/using-jobs/using-conditions-to-control-job-execution). Synchronizing changes from the upstream repo in a downstream repo always triggers CI tests (see also: [the action logs in my fork](https://github.com/yin1999/dubbo-kubernetes/actions/workflows/ci.yml)), but this would not bring any benefit.

## How to verify this change

Check the documentation: https://docs.github.com/actions/using-jobs/using-conditions-to-control-job-execution
