### PR TITLE
fix: update download dubbo link in downloadDubbo.sh

### DIFF
--- a/release/downloadDubbo.sh
+++ b/release/downloadDubbo.sh
@@ -25,7 +25,7 @@ fi
 
 # Determine the latest Dubbo version by version number ignoring alpha, beta, and rc versions.
 if [ "${DUBBO_VERSION}" = "" ] ; then
-  DUBBO_VERSION="$(curl -sL https://github.com/apache/dubbo/releases | \
+  DUBBO_VERSION="$(curl -sL  https://github.com/apache/dubbo-kubernetes/releases | \
                   grep -E -o 'dubbo/([v,V]?)[0-9]*.[0-9]*.[0-9]*' | sort -V | \
                   tail -1 | awk -F'/' '{ print $2}')"
   DUBBO_VERSION="${DUBBO_VERSION##*/}"
@@ -66,7 +66,7 @@ download_failed () {
 tmp=$(mktemp -d /tmp/dubbo.XXXXXX)
 NAME="dubboctl-${DUBBO_VERSION}"
 
-ARCH_URL="https://github.com/apache/dubbo/releases/download/dubbo%2F${DUBBO_VERSION}/dubbo-${DUBBO_VERSION}-${OSEXT}-${DUBBO_ARCH}.tar.gz"
+ARCH_URL=" https://github.com/apache/dubbo-kubernetes/releases/download/dubbo%2F${DUBBO_VERSION}/dubbo-${DUBBO_VERSION}-${OSEXT}-${DUBBO_ARCH}.tar.gz"
 
 with_arch() {
   printf "\nDownloading %s from %s ...\n" "${NAME}" "$ARCH_URL"


### PR DESCRIPTION
## What is the purpose of the change
- For https://github.com/apache/dubbo-kubernetes/pull/116/files/5be8a3392d44d4c8351a2a1904fa1f965fcbaf8c#r1431393108

