### PR TITLE
feat(creds): support containers-auth.json

### DIFF
--- a/app/dubboctl/internal/docker/creds/credentials.go
+++ b/app/dubboctl/internal/docker/creds/credentials.go
@@ -180,8 +180,12 @@ func NewCredentialsProvider(configPath string, opts ...Opt) docker.CredentialsPr
 	}
 
 	c.authFilePath = filepath.Join(configPath, "auth.json")
-	sys := &containersTypes.SystemContext{
+	dockerSys := &containersTypes.SystemContext{
 		AuthFilePath: c.authFilePath,
+	}
+
+	podmanSys := &containersTypes.SystemContext{
+		AuthFilePath: getPodmanAuthFilePath(),
 	}
 
 	home, err := os.UserHomeDir()
@@ -197,8 +201,24 @@ func NewCredentialsProvider(configPath string, opts ...Opt) docker.CredentialsPr
 		func(registry string) (docker.Credentials, error) {
 			return getCredentialsByCredentialHelper(dockerConfigPath, registry)
 		},
+		// docker auth config
 		func(registry string) (docker.Credentials, error) {
-			creds, err := dockerConfig.GetCredentials(sys, registry)
+			creds, err := dockerConfig.GetCredentials(dockerSys, registry)
+			if err != nil {
+				return docker.Credentials{}, err
+			}
+			return docker.Credentials{
+				Username: creds.Username,
+				Password: creds.Password,
+			}, nil
+		},
+		// podman auth config
+		func(registry string) (docker.Credentials, error) {
+			if podmanSys.AuthFilePath == "" {
+				// podman auth config is not available
+				return docker.Credentials{}, ErrCredentialsNotFound
+			}
+			creds, err := dockerConfig.GetCredentials(podmanSys, registry)
 			if err != nil {
 				return docker.Credentials{}, err
 			}
@@ -403,6 +423,24 @@ func setCredentialsByCredentialHelper(confFilePath, registry, username, secret s
 	p := client.NewShellProgramFunc(helperName)
 
 	return client.Store(p, &credentials.Credentials{ServerURL: registry, Username: username, Secret: secret})
+}
+
+// getPodmanAuthFilePath returns the path to the podman auth file.
+// documentation for the auth file can be found here:
+// https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md
+func getPodmanAuthFilePath() string {
+	if runtime.GOOS == "windows" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		return filepath.Join(homeDir, ".config", "containers", "auth.json")
+	}
+	xdgRuntimeDir := os.Getenv("XDG_RUNTIME_DIR")
+	if xdgRuntimeDir == "" {
+		return ""
+	}
+	return filepath.Join(xdgRuntimeDir, "containers", "auth.json")
 }
 
 func listCredentialHelpers() []string {


### PR DESCRIPTION
## What is the purpose of the change

support containers-auth.json, part of: #93

## How to verify this change

Verified `dubboctl` can correctly read the auth information from the `auth.json` which is stored without [credential helper](https://github.com/docker/docker-credential-helpers). Tested on Debian testing and Windows 10.

---

Linux testing (with `DOCKER_HOST="unix://${XDG_RUNTIME_DIR}/podman/podman.sock"` env set):

![image](https://github.com/apache/dubbo-kubernetes/assets/15844309/6f024b38-2acc-474f-b557-602d0f7c5230)

---

Windows testing ([installation guide](https://github.com/containers/podman/blob/main/docs/tutorials/podman-for-windows.md)):

![image](https://github.com/apache/dubbo-kubernetes/assets/15844309/5cef8a06-bdb8-4ffe-9aca-a8dcfbf83dd3)

Other tests we can do in the future:

- test with the  [credential helper](https://github.com/docker/docker-credential-helpers), currently, podman does not support credential helper with rootless mode.
