### PR TITLE
fix(xds): correct the configuration of the xds server

### DIFF
--- a/pkg/xds/server/v3/components.go
+++ b/pkg/xds/server/v3/components.go
@@ -117,7 +117,8 @@ func DefaultDataplaneStatusTracker(rt core_runtime.Runtime) xds_callbacks.Datapl
 					return time.NewTicker(rt.Config().XdsServer.DataplaneStatusFlushInterval.Duration)
 				},
 				func() *time.Ticker {
-					return nil
+					// Use default settings for now
+					return time.NewTicker(5 * time.Minute)
 				},
 				rt.Config().XdsServer.DataplaneStatusFlushInterval.Duration/10,
 				xds_callbacks.NewDataplaneInsightStore(rt.ResourceManager()),

--- a/pkg/xds/sync/componenets.go
+++ b/pkg/xds/sync/componenets.go
@@ -78,7 +78,7 @@ func DefaultDataplaneWatchdogFactory(
 		ResManager:            rt.ReadOnlyResourceManager(),
 	}
 	return NewDataplaneWatchdogFactory(
-		10,
+		config.XdsServer.DataplaneConfigurationRefreshInterval.Duration,
 		deps,
 	)
 }


### PR DESCRIPTION
## What is the purpose of the change

correct the configuration of the xds server. Changes:

- add the ticker for generation increment, as we may use the dataplane insight in the future, so fix this by adding the ticker instead of removing the Dataplane insight logic.
- correctly configure the synchronization interval, `10` nanosecond by default is too fast. Use the `RefreshInterval` instead.
