### PR TITLE
fix(dubboctl): resolve the init logic of k8s environment

### DIFF
--- a/app/dubboctl/cmd/manifest_generate.go
+++ b/app/dubboctl/cmd/manifest_generate.go
@@ -111,7 +111,7 @@ func addManifestGenerateFlags(cmd *cobra.Command, args *ManifestGenerateArgs) {
 	cmd.PersistentFlags().StringVarP(&args.ChartsPath, "charts", "", "",
 		"Path to charts directory, this directory contains components charts")
 	cmd.PersistentFlags().StringVarP(&args.ProfilesPath, "profiles", "", "",
-		"Path to profiles directory, this directory contains preset profiles")
+		"Path to profiles directory, this directory contains preset profiles, default to built-in profiles")
 	cmd.PersistentFlags().StringVarP(&args.OutputPath, "output", "o", "",
 		"Path to output manifest, if not set, dubboctl would print the manifest")
 	cmd.PersistentFlags().StringArrayVarP(&args.SetFlags, "set", "s", nil,

--- a/app/dubboctl/cmd/manifest_install.go
+++ b/app/dubboctl/cmd/manifest_install.go
@@ -46,6 +46,9 @@ func ConfigManifestInstallCmd(baseCmd *cobra.Command) {
 		Short: "install dubbo control plane",
 		Example: `  # Install a default Dubbo control plane
   dubboctl manifest install
+
+  # Install the demo environment
+  dubboctl manifest install --set profile=demo
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logger.InitCmdSugar(zapcore.AddSync(cmd.OutOrStdout()))

--- a/app/dubboctl/internal/manifest/render/render.go
+++ b/app/dubboctl/internal/manifest/render/render.go
@@ -55,7 +55,7 @@ const (
 var DefaultFilters = []util.FilterFunc{
 	util.LicenseFilter,
 	util.FormatterFilter,
-	util.SpaceFilter,
+	util.ReserveEoFSpaceFilter,
 }
 
 // Renderer is responsible for rendering helm chart with new values.
@@ -325,8 +325,10 @@ func renderManifest(valsYaml string, cht *chart.Chart, builtIn bool, opts *Rende
 		if file == "" {
 			continue
 		}
+		// the formatted yaml file should terminate with a newline separator
 		if !strings.HasSuffix(file, YAMLSeparator) {
-			file += YAMLSeparator
+			// do not add the first newline separator
+			file += YAMLSeparator[1:]
 		}
 		builder.WriteString(file)
 	}

--- a/app/dubboctl/internal/util/filter.go
+++ b/app/dubboctl/internal/util/filter.go
@@ -68,6 +68,15 @@ func SpaceFilter(input string) string {
 	return strings.TrimSpace(input)
 }
 
+func ReserveEoFSpaceFilter(input string) string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return ""
+	}
+	// reserve one space line at the end of file
+	return input + "\n"
+}
+
 // SpaceLineFilter removes all space lines.
 func SpaceLineFilter(input string) string {
 	var builder strings.Builder

--- a/deploy/charts/nacos/.helmignore
+++ b/deploy/charts/nacos/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/charts/nacos/Chart.yaml
+++ b/deploy/charts/nacos/Chart.yaml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+appVersion: "1.0"
+name: nacos
+description: an easy-to-use dynamic service discovery, configuration and service management platform for building cloud native applications.
+home: https://nacos.io
+kubeVersion: '>=1.20.0-0'
+maintainers:
+  - email: dev@dubbo.apache.org
+    name: dubbo
+sources:
+  - https://github.com/alibaba/nacos
+type: application
+version: 0.1.5

--- a/deploy/charts/nacos/templates/_charts.tpl
+++ b/deploy/charts/nacos/templates/_charts.tpl
@@ -1,0 +1,111 @@
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nacos.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nacos.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nacos.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Nacos Namespace to use
+*/}}
+{{- define "nacos.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+{{- else -}}
+    {{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "nacos.labels" -}}
+app.kubernetes.io/name: {{ include "nacos.name" . }}
+helm.sh/chart: {{ include "nacos.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Labels to use on sts.spec.selector.matchLabels and svc.spec.selector
+*/}}
+{{- define "nacos.matchLabels" -}}
+app.kubernetes.io/name: {{ include "nacos.name" . }}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for networkpolicy.
+*/}}
+{{- define "nacos.networkPolicy.apiVersion" -}}
+{{- if semverCompare "<1.7-0" (include "nacos.kubeVersion" .) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for poddisruptionbudget.
+*/}}
+{{- define "nacos.policy.apiVersion" -}}
+{{- if semverCompare "<1.21-0" (include "nacos.kubeVersion" .) -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "policy/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the target Kubernetes version
+*/}}
+{{- define "nacos.kubeVersion" -}}
+{{- if .Values.global }}
+    {{- if .Values.global.kubeVersion }}
+    {{- .Values.global.kubeVersion -}}
+    {{- else }}
+    {{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+    {{- end -}}
+{{- else }}
+{{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+{{- end -}}
+{{- end -}}
+{{/*
+Return the appropriate apiVersion for statefulset.
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/deploy/charts/nacos/templates/configmap.yaml
+++ b/deploy/charts/nacos/templates/configmap.yaml
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if eq .Values.storage.type "mysql"}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "nacos.fullname" . }}-configmap
+  namespace: {{ template "nacos.namespace" . }}
+data:
+  {{- with .Values.storage.db }}
+  mysql.db.host: {{ .host }}
+  mysql.db.name: {{ .name }}
+  mysql.port: "{{ .port | default 3306 }}"
+  mysql.user: {{ .username }}
+  mysql.password: {{ .password }}
+  mysql.param: {{ .param | default "characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useSSL=false" }}
+  {{- end }}
+  {{- end }}

--- a/deploy/charts/nacos/templates/extra-list.yaml
+++ b/deploy/charts/nacos/templates/extra-list.yaml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- range .Values.extraDeploy }}
+---
+{{ include "tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/deploy/charts/nacos/templates/networkpolicy.yaml
+++ b/deploy/charts/nacos/templates/networkpolicy.yaml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1 {{ include "nacos.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ include "nacos.fullname" . }}
+  namespace: {{ template "nacos.namespace" . }}
+  labels: {{- include "nacos.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels: {{- include "nacos.matchLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: {{ .Values.service.port }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ include "nacos.fullname" . }}-client: "true"
+        - podSelector:
+            matchLabels: {{- include "nacos.matchLabels" . | nindent 14 }}
+    - ports:
+        - port: {{ .Values.service.port }}
+      from:
+        - podSelector:
+            matchLabels: {{- include "nacos.matchLabels" . | nindent 14 }}
+  {{- end }}

--- a/deploy/charts/nacos/templates/pdb.yaml
+++ b/deploy/charts/nacos/templates/pdb.yaml
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- $replica := int .Values.replicas }}
+{{- if and .Values.podDisruptionBudget.enabled (gt $replica 1) }}
+apiVersion: {{ include "nacos.policy.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "nacos.fullname" . }}
+  namespace: {{ template "nacos.namespace" . }}
+  labels: {{- include "nacos.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end  }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end  }}
+  selector:
+    matchLabels: {{- include "nacos.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/charts/nacos/templates/statefulset.yaml
+++ b/deploy/charts/nacos/templates/statefulset.yaml
@@ -1,0 +1,179 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "nacos.fullname" . }}
+  namespace: {{ template "nacos.namespace" . }}
+spec:
+  replicas: {{ .Values.replicas }}
+  {{- if eq .Values.global.mode "cluster" }}
+  serviceName: nacos-headless
+  {{- else }}
+  serviceName: nacos
+  {{- end }}
+  selector:
+    matchLabels: {{- include "nacos.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nacos
+    spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if and (eq .Values.global.mode "cluster") (.Values.plugin.enable) }}
+      initContainers:
+        - name: peer-finder-plugin-install
+          image: {{.Values.plugin.image.repository }}:{{.Values.plugin.image.tag }}
+          imagePullPolicy: {{ .Values.plugin.image.pullPolicy }}
+          volumeMounts:
+            - mountPath: /home/nacos/plugins/peer-finder
+              name: data
+              subPath: peer-finder
+      {{- end }}
+      containers:
+        - name: nacos
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          startupProbe:
+            initialDelaySeconds: 180
+            periodSeconds: 5
+            timeoutSeconds: 10
+            httpGet:
+              scheme: HTTP
+              port: {{ .Values.service.port }}
+              path: /nacos/v1/console/health/readiness
+          livenessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 10
+            httpGet:
+              scheme: HTTP
+              port: {{ .Values.service.port }}
+              path: /nacos/v1/console/health/liveness
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+            - containerPort: {{ add .Values.service.port 1000 }}
+              name: client-rpc
+            - containerPort: {{ add .Values.service.port 1001 }}
+              name: raft-rpc
+            - containerPort: 7848
+              name: old-raft-rpc
+          resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: NACOS_SERVER_PORT
+              value: {{ .Values.service.port | quote }}
+            - name: NACOS_APPLICATION_PORT
+              value: {{ .Values.service.port | quote }}
+            - name: PREFER_HOST_MODE
+              value: {{ .Values.service.port | quote }}
+            {{- if eq .Values.global.mode "standalone" }}
+            - name: MODE
+              value: "standalone"
+            {{- else if eq .Values.global.mode "cluster" }}
+            - name: SERVICE_NAME
+              value: "nacos-headless"
+            - name: DOMAIN_NAME
+              value: {{ .Values.domainName | quote }}
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            {{- end }}
+            {{- if eq .Values.storage.type "mysql" }}
+            - name: SPRING_DATASOURCE_PLATFORM
+              value: "mysql"
+            - name: MYSQL_SERVICE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: nacos-configmap
+                  key: mysql.db.host
+            - name: MYSQL_SERVICE_DB_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: nacos-configmap
+                  key: mysql.db.name
+            - name: MYSQL_SERVICE_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: nacos-configmap
+                  key: mysql.port
+            - name: MYSQL_SERVICE_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: nacos-configmap
+                  key: mysql.user
+            - name: MYSQL_SERVICE_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: nacos-configmap
+                  key: mysql.password
+            - name: MYSQL_SERVICE_DB_PARAM
+              valueFrom:
+                configMapKeyRef:
+                  name: nacos-configmap
+                  key: mysql.param
+            {{- else }}
+            - name: EMBEDDED_STORAGE
+              value: embedded
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /home/nacos/plugins/peer-finder
+              subPath: peer-finder
+            - name: data
+              mountPath: /home/nacos/data
+              subPath: data
+            - name: data
+              mountPath: /home/nacos/logs
+              subPath: logs
+      {{- if not .Values.persistence.enabled }}
+      volumes:
+        - name: data
+          emptyDir: {}
+  {{- end }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+        {{- range .Values.persistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+        {{ if .Values.persistence.ClaimName }}
+            claimName: {{ .Values.persistence.ClaimName }}
+        {{- else -}}
+            emptyDir: {{ .Values.persistence.emptyDir }}
+  {{- end }}
+  {{- end }}

--- a/deploy/charts/nacos/templates/svc-headless.yaml
+++ b/deploy/charts/nacos/templates/svc-headless.yaml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if and (eq .Values.global.mode "cluster") }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "nacos.name" . }}-headless
+  namespace: {{ template "nacos.namespace" }}
+  labels: {{- include "nacos.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+      name: http
+    - port: {{ add .Values.service.port 1000 }}
+      name: client-rpc
+      targetPort: {{ add .Values.service.port 1000 }}
+    - port: {{ add .Values.service.port 1001 }}
+      name: raft-rpc
+      targetPort: {{ add .Values.service.port 1001 }}
+    - port: 7848
+      name: old-raft-rpc
+      targetPort: 7848
+      protocol: TCP
+  selector: {{- include "nacos.matchLabels" . | nindent 4 }}
+  {{- end }}

--- a/deploy/charts/nacos/templates/svc.yaml
+++ b/deploy/charts/nacos/templates/svc.yaml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "nacos.name" . }}
+  namespace: {{ template "nacos.namespace" . }}
+  labels: {{- include "nacos.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+      name: http
+    - port: {{ add .Values.service.port 1000 }}
+      name: client-rpc
+      targetPort: {{add .Values.service.port 1000 }}
+    - port: {{add .Values.service.port 1001 }}
+      name: raft-rpc
+      targetPort: {{add .Values.service.port 1001 }}
+    - port: 7848
+      name: old-raft-rpc
+      targetPort: 7848
+      protocol: TCP
+      {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.service.nodePort }}
+  {{- end }}
+  selector: {{- include "nacos.matchLabels" . | nindent 4 }}

--- a/deploy/charts/nacos/values.yaml
+++ b/deploy/charts/nacos/values.yaml
@@ -1,0 +1,181 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+global:
+  mode: standalone
+  # mode: cluster
+
+image:
+  registry: docker.io
+  #  e.g registry.k8s.io
+  repository: nacos/nacos-server
+  tag: latest
+  pullPolicy: IfNotPresent
+
+plugin:
+  enable: true
+  # true or false
+  image:
+    repository: nacos/nacos-peer-finder-plugin
+    tag: 1.1
+    pullPolicy: IfNotPresent
+
+replicas: 1
+
+domainName: cluster.local
+
+extraDeploy: []
+
+nodeSelector: []
+
+affinity: []
+
+tolerations: []
+
+maxUnavailable: []
+
+resources:
+  limits: {}
+  requests: {}
+
+storage:
+  type: ~
+  # db:
+    # host: localhost
+    # name: nacos
+    # port: 3306
+    # username: usernmae
+    # password: password
+    # param: characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useSSL=false
+
+service:
+  name: http
+  ##
+  ## Service name.
+  ##
+  type: NodePort
+  ##
+  ## Service type.
+  ##
+  port: 8848
+  ##
+  ## Service port.
+  ##
+  nodePort: 30000
+  ##
+  ## Service nodePort.
+  ##
+  clusterIP: ""
+  ##
+  ## Service clusterIP.
+  ##
+  loadBalancerIP: ""
+  ##
+  ## Service loadBalancerIP.
+  ##
+  loadBalancerSourceRanges: ""
+  ##
+  ## Service loadBalancerSourceRanges.
+  ##
+  externalIPs: ""
+  ##
+  ## Service externalIPs.
+
+persistence:
+  enabled: false
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ""
+  size: 5Gi
+  ClaimName: {}
+  ## persistence emptyDir
+  emptyDir: {}
+
+## See `kubectl explain poddisruptionbudget.spec` for more
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
+ingress:
+  enabled: false
+  # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+  # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+  # ingressClassName: nginx
+  # Values can be templated
+  annotations: {}
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
+  labels: {}
+  path: /
+  ##
+  ##
+  # pathType is only for k8s >= 1.1=
+  pathType: Prefix
+  ##
+  ##
+  hosts:
+    - chart-example.local
+  ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+  extraPaths: []
+  # - path: /*
+  #   backend:
+  #     serviceName: ssl-redirect
+  #     servicePort: use-annotation
+  ## Or for k8s > 1.19
+  # - path: /*
+  #   pathType: Prefix
+  #   backend:
+  #     service:
+  #       name: ssl-redirect
+  #       port:
+  #         name: use-annotation
+  ##
+  ##
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+networkPolicy:
+  ## @param networkPolicy.enabled Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
+  ##
+  enabled: false
+  ## @param networkPolicy.allowExternal Don't require client label for connections
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to  dubbo-admin port defined.
+  ## When true, dubbo-admin will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  ingress: true
+  ## @param networkPolicy.ingress When true enables the creation
+  ## an ingress network policy
+  ##
+  ##
+  ##
+  ##
+  egress:
+    ## @param networkPolicy.egress.enabled When enabled, an egress network policy will be
+    ## created allowing dubbo-admin to connect to external data sources from kubernetes cluster.
+    enabled: false
+    ##
+    ## @param networkPolicy.egress.ports Add individual ports to be allowed by the egress
+    ports: []
+      ## Add ports to the egress by specifying - port: <port number>
+      ## E.X.
+      ## ports:
+      ## - port: 80
+    ## - port: 443


### PR DESCRIPTION
## What is the purpose of the change

resolve the init logic of k8s environment, as the command given in [guide](https://dubbo-next.staged.apache.org/zh-cn/overview/mannual/java-sdk/quick-start/deploy/) cannot work correctly.

The config map of nacos is from [https://github.com/chickenlj/dubbo-admin/tree/refactor-with-go-integration/deploy](https://github.com/chickenlj/dubbo-admin/tree/0c5a543d5ab76b208508628bf48302e547a186fc/deploy).

## Brief changelog

resolve the init logic of k8s environment

## Verifying this change

Run the following command to init the k8s environment:

```bash
dubboctl manifest install --set profile=demo

# check the services
kubectl get services -n dubbo-system
```

## CheckList
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo-kubernetes/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).