### PR TITLE
[fix] fix ci && Dubboctl deploy subcommand error fix

### DIFF
--- a/app/dubboctl/cmd/deploy.go
+++ b/app/dubboctl/cmd/deploy.go
@@ -103,6 +103,8 @@ SYNOPSIS
 		"Whether to build the image")
 	cmd.Flags().BoolP("apply", "a", false,
 		"Whether to apply the application to the k8s cluster by the way")
+	cmd.Flags().StringP("portName", "", "http",
+		"Name of the port to be exposed")
 
 	addPathFlag(cmd)
 	cmd.Flags().SetInterspersed(false)
@@ -279,6 +281,9 @@ func (c DeployConfig) Configure(f *dubbo.Dubbo) {
 	if c.NodePort != 0 {
 		f.Deploy.NodePort = c.NodePort
 	}
+	if c.PortName != "" {
+		f.Deploy.PortName = c.PortName
+	}
 }
 
 type DeployConfig struct {
@@ -293,6 +298,7 @@ type DeployConfig struct {
 	Force         bool
 	TargetPort    int
 	NodePort      int
+	PortName      string
 }
 
 func newDeployConfig(cmd *cobra.Command) (c *DeployConfig) {
@@ -308,6 +314,7 @@ func newDeployConfig(cmd *cobra.Command) (c *DeployConfig) {
 		ContainerPort: viper.GetInt("containerPort"),
 		TargetPort:    viper.GetInt("targetPort"),
 		NodePort:      viper.GetInt("nodePort"),
+		PortName:      viper.GetString("portName"),
 	}
 	return
 }

--- a/app/dubboctl/internal/dubbo/deploy.tpl
+++ b/app/dubboctl/internal/dubbo/deploy.tpl
@@ -68,10 +68,12 @@ spec:
     port: {{.Port}}
     protocol: TCP
     targetPort: {{.TargetPort}}
-  type: NodePort{{else}}- port: {{.Port}}
-    targetPort: {{.TargetPort}}{{end}}{{if .UseProm}}
+    name: {{.PortName}}{{else}}- port: {{.Port}}
+    targetPort: {{.TargetPort}}
+    name: {{.PortName}}{{end}}{{if .UseProm}}
   - port: 18081
-    targetPort: 18081{{end}}
+    targetPort: 18081
+    name: metrics{{end}}
   selector:
     app: {{.Name}}
 

--- a/app/dubboctl/internal/dubbo/deployer.go
+++ b/app/dubboctl/internal/dubbo/deployer.go
@@ -59,6 +59,7 @@ type Deployment struct {
 	NodePort    int
 	UseNodePort bool
 	UseProm     bool
+	PortName    string
 }
 
 func (d *DeployApp) Deploy(ctx context.Context, f *Dubbo, option ...DeployOption) (DeploymentResult, error) {
@@ -104,6 +105,7 @@ func (d *DeployApp) Deploy(ctx context.Context, f *Dubbo, option ...DeployOption
 		NodePort:    f.Deploy.NodePort,
 		UseNodePort: nodePort > 0,
 		UseProm:     f.Deploy.UseProm,
+		PortName:    f.Deploy.PortName,
 	})
 	if err != nil {
 		return DeploymentResult{

--- a/app/dubboctl/internal/dubbo/dubbo.go
+++ b/app/dubboctl/internal/dubbo/dubbo.go
@@ -132,6 +132,7 @@ type DeploySpec struct {
 	TargetPort    int    `yaml:"targetPort,omitempty"`
 	NodePort      int    `yaml:"nodePort,omitempty"`
 	UseProm       bool   `yaml:"-"`
+	PortName      string `yaml:"portName,omitempty"`
 }
 
 func (f *Dubbo) Validate() error {

--- a/pkg/admin/handler/service.go
+++ b/pkg/admin/handler/service.go
@@ -19,19 +19,22 @@ package handler
 
 import (
 	"errors"
-	"github.com/apache/dubbo-kubernetes/pkg/admin/service"
 	"net/http"
 	"strconv"
 )
 
 import (
+	"github.com/gin-gonic/gin"
+)
+
+import (
 	mesh_proto "github.com/apache/dubbo-kubernetes/api/mesh/v1alpha1"
 	"github.com/apache/dubbo-kubernetes/pkg/admin/model"
+	"github.com/apache/dubbo-kubernetes/pkg/admin/service"
 	"github.com/apache/dubbo-kubernetes/pkg/core/consts"
 	"github.com/apache/dubbo-kubernetes/pkg/core/resources/apis/mesh"
 	core_store "github.com/apache/dubbo-kubernetes/pkg/core/resources/store"
 	core_runtime "github.com/apache/dubbo-kubernetes/pkg/core/runtime"
-	"github.com/gin-gonic/gin"
 )
 
 // API Definition: https://app.apifox.com/project/3732499

--- a/pkg/admin/handler/service.go
+++ b/pkg/admin/handler/service.go
@@ -19,12 +19,9 @@ package handler
 
 import (
 	"errors"
+	"github.com/apache/dubbo-kubernetes/pkg/admin/service"
 	"net/http"
 	"strconv"
-)
-
-import (
-	"github.com/gin-gonic/gin"
 )
 
 import (


### PR DESCRIPTION
Dubdoctl deploy subcommand error fix: The port field of the generated service is missing a name.