### PR TITLE
chore(ci): bump the versions of Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,10 @@ jobs:
 #        golang:
 #          - '1.21'
 #    steps:
-#      - uses: actions/setup-go@v3
+#      - uses: actions/setup-go@v5
 #        with:
 #          go-version: ${{ matrix.go_version }}
-#      - uses: actions/checkout@v3
+#      - uses: actions/checkout@v4
 #      - name: golangci-lint
 #        uses: golangci/golangci-lint-action@v3.4.0
 #        with:
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go 1.x
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - name: Download dependencies
@@ -67,7 +67,7 @@ jobs:
           go test ./... -gcflags=-l -coverprofile=coverage.txt -covermode=atomic
       - name: "Upload test result"
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-coverage
           path: "**/coverage.txt"
@@ -81,7 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go 1.x
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go 1.x
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - name: Download dependencies

--- a/.github/workflows/dubbo-release.yaml
+++ b/.github/workflows/dubbo-release.yaml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go 1.x
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/dubboctl-release.yaml
+++ b/.github/workflows/dubboctl-release.yaml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go 1.x
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
## What is the purpose of the change

`setup-go@v4` and `upload-artifact@v3` are using a deprecated Node.js version, we should bump the versions to resolve  it. See also:

- https://github.com/apache/dubbo-kubernetes/actions/runs/11536707130
- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

See changelogs:

- https://github.com/actions/setup-go?tab=readme-ov-file#v5
- https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new

## Brief changelog

- bump the versions of Actions

## Verifying this change

Check the output of GitHub Actions.

## CheckList
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo-kubernetes/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. 
- [x GitHub Actions works fine on your own branch.
- [x] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).