### PR TITLE
fix(applications):  Fix the issue of editing key value pairs in application weight configuration

### DIFF
--- a/ui-vue3/src/views/resources/applications/tabs/config.vue
+++ b/ui-vue3/src/views/resources/applications/tabs/config.vue
@@ -305,7 +305,7 @@ const updateFlowWeight = async () => {
         weight.scope.forEach((scopeItem: any) => {
           const { key, value, condition } = scopeItem
           let scopeItemTem = {
-            key: scopeItem.label,
+            key: scopeItem.label || key,
             value: {}
           }
           if (condition) {


### PR DESCRIPTION
## What is the purpose of the change
Fixed the error caused by not passing the key when updating weights

## Brief changelog
-In weight configuration, when scopeItem.label is empty, use scopeItem.key as an alternative value
-This modification ensures that key values can be displayed correctly even if the label is empty when editing weight configurations

## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## CheckList
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo-kubernetes/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. 
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).