### PR TITLE
[Admin]fix: reuse clientset to avoid initializing clientset repeatedly

### DIFF
--- a/app/dubbo-cp/dubbo-cp.yaml
+++ b/app/dubbo-cp/dubbo-cp.yaml
@@ -26,11 +26,11 @@ mode: zone
 #      address: zookeeper://localhost:2181
 store:
   traditional:
-    config_center: nacos://47.251.165.168:8848?username=nacos&password=nacos
+    config_center: nacos://47.76.94.134:8848?username=nacos&password=nacos
     registry:
-      address: nacos://47.251.165.168:8848?username=nacos&password=nacos
+      address: nacos://47.76.94.134:8848?username=nacos&password=nacos
     metadata_report:
-      address: nacos://47.251.165.168:8848?username=nacos&password=nacos
+      address: nacos://47.76.94.134:8848?username=nacos&password=nacos
 admin:
   metric_dashboards:
     application:

--- a/pkg/core/bootstrap/bootstrap.go
+++ b/pkg/core/bootstrap/bootstrap.go
@@ -19,6 +19,7 @@ package bootstrap
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -374,14 +375,19 @@ func initializeResourceManager(cfg dubbo_cp.Config, builder *core_runtime.Builde
 			return errors.New("get kube manager err")
 		}
 	}
+	dataplaneManager, err := dataplane_managers.NewDataplaneManager(
+		builder.ResourceStore(),
+		cfg.Multizone.Zone.Name,
+		manager,
+		deployMode,
+	)
+	if err != nil {
+		return fmt.Errorf("initializing datalane manager error: %w", err)
+	}
 	customizableManager.Customize(
 		mesh.DataplaneType,
-		dataplane_managers.NewDataplaneManager(
-			builder.ResourceStore(),
-			cfg.Multizone.Zone.Name,
-			manager,
-			deployMode,
-		))
+		dataplaneManager,
+	)
 
 	customizableManager.Customize(
 		mesh.MappingType,


### PR DESCRIPTION
## What is the purpose of the change
Reuse clientset to avoid initializing clientset repeatedly

## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## CheckList
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo-kubernetes/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. 
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).