### PR TITLE
Fix CI startup policy and require quality gate

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -36,8 +36,9 @@ github:
     # Enable wiki for documentation
     wiki: false
   protected_branches:
-    master: {}
-    # only disable force push
-    # foo: bar
-
-
+    master:
+      required_status_checks:
+        strict: true
+        contexts:
+          # This stable aggregate check fails unless every required CI job passes.
+          - CI Required

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
           file: ./coverage.txt
           flags: unittests
           name: codecov-umbrella
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   performance:
     name: Performance Scale Smoke
@@ -182,9 +182,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: 'v3.16.4'
+        run: tools/ci/install-helm.sh v3.16.4
 
       - name: Lint and render charts
         run: make lint-helm
@@ -199,17 +197,57 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: 'v3.16.4'
+        run: tools/ci/install-helm.sh v3.16.4
 
       - name: Install kind
-        uses: helm/kind-action@v1
-        with:
-          install_only: true
-          version: 'v0.30.0'
+        run: tools/ci/install-kind.sh v0.30.0
 
       - name: Run e2e smoke test
         env:
           UPGRADE_FROM_VERSION: '0.4.3'
         run: make test-e2e
+
+  required:
+    name: CI Required
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ always() }}
+    needs:
+      - lint
+      - check
+      - unit-test
+      - performance
+      - build
+      - helm
+      - e2e
+    steps:
+      - name: Verify required jobs passed
+        env:
+          LINT_RESULT: ${{ needs.lint.result }}
+          CHECK_RESULT: ${{ needs.check.result }}
+          UNIT_TEST_RESULT: ${{ needs.unit-test.result }}
+          PERFORMANCE_RESULT: ${{ needs.performance.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          HELM_RESULT: ${{ needs.helm.result }}
+          E2E_RESULT: ${{ needs.e2e.result }}
+        run: |
+          failed=0
+          for job_result in \
+            "lint=${LINT_RESULT}" \
+            "check=${CHECK_RESULT}" \
+            "unit-test=${UNIT_TEST_RESULT}" \
+            "performance=${PERFORMANCE_RESULT}" \
+            "build=${BUILD_RESULT}" \
+            "helm=${HELM_RESULT}" \
+            "e2e=${E2E_RESULT}"; do
+            job="${job_result%%=*}"
+            result="${job_result#*=}"
+            echo "${job}: ${result}"
+            if [[ "${result}" != "success" ]]; then
+              failed=1
+            fi
+          done
+          if [[ "${failed}" -ne 0 ]]; then
+            echo "Required CI job did not succeed." >&2
+            exit 1
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -238,9 +238,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v5.0.1
-        with:
-          version: 'v3.16.4'
+        run: tools/ci/install-helm.sh v3.16.4
 
       - name: Lint, package, and verify charts
         env:

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -23,6 +23,9 @@ header:
     - '**/*.pb.go'
     - '**/*.gen.go'
     - '**/*.cache'
+
+    # Upstream KRT sources retain the Istio Authors Apache-2.0 header.
+    - 'pkg/kube/krt/**'
     
     # Configuration and template files
     - '**/*.proto'
@@ -58,6 +61,7 @@ header:
     
     # Test data
     - '**/testdata/**'
+    - '**/*.pem'
     
     # Log files
     - '**/*.log'

--- a/dubboctl/cmd/admin_test.go
+++ b/dubboctl/cmd/admin_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/dubboctl/cmd/dashboard_test.go
+++ b/dubboctl/cmd/dashboard_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/dubboctl/cmd/get_test.go
+++ b/dubboctl/cmd/get_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/dubboctl/cmd/gui.go
+++ b/dubboctl/cmd/gui.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/dubboctl/cmd/gui_test.go
+++ b/dubboctl/cmd/gui_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import "testing"

--- a/dubboctl/cmd/multicluster.go
+++ b/dubboctl/cmd/multicluster.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/dubboctl/cmd/multicluster_test.go
+++ b/dubboctl/cmd/multicluster_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/dubbod/discovery/cmd/app/grpc_inbound_test.go
+++ b/dubbod/discovery/cmd/app/grpc_inbound_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package app
 
 import (

--- a/dubbod/discovery/cmd/app/grpc_outbound_test.go
+++ b/dubbod/discovery/cmd/app/grpc_outbound_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package app
 
 import (

--- a/dubbod/discovery/pkg/bootstrap/gateway_multicluster.go
+++ b/dubbod/discovery/pkg/bootstrap/gateway_multicluster.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package bootstrap
 
 import (

--- a/dubbod/discovery/pkg/bootstrap/gui.go
+++ b/dubbod/discovery/pkg/bootstrap/gui.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package bootstrap
 
 import (

--- a/dubbod/discovery/pkg/bootstrap/gui_test.go
+++ b/dubbod/discovery/pkg/bootstrap/gui_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package bootstrap
 
 import (

--- a/dubbod/discovery/pkg/model/authentication_test.go
+++ b/dubbod/discovery/pkg/model/authentication_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package model
 
 import (

--- a/dubbod/discovery/pkg/networking/grpcgen/mtls_test.go
+++ b/dubbod/discovery/pkg/networking/grpcgen/mtls_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package grpcgen
 
 import (

--- a/dubbod/discovery/pkg/serviceregistry/serviceentry/controller_test.go
+++ b/dubbod/discovery/pkg/serviceregistry/serviceentry/controller_test.go
@@ -132,7 +132,7 @@ func (f *fakeConfigController) HasSynced() bool          { return true }
 
 func (f *fakeConfigController) create(t *testing.T, cfg config.Config) {
 	t.Helper()
-	if _, err := f.ConfigStore.Create(cfg); err != nil {
+	if _, err := f.Create(cfg); err != nil {
 		t.Fatal(err)
 	}
 	current := *f.Get(cfg.GroupVersionKind, cfg.Name, cfg.Namespace)
@@ -145,7 +145,7 @@ func (f *fakeConfigController) update(t *testing.T, cfg config.Config) {
 	t.Helper()
 	old := *f.Get(cfg.GroupVersionKind, cfg.Name, cfg.Namespace)
 	cfg.ResourceVersion = ""
-	if _, err := f.ConfigStore.Update(cfg); err != nil {
+	if _, err := f.Update(cfg); err != nil {
 		t.Fatal(err)
 	}
 	current := *f.Get(cfg.GroupVersionKind, cfg.Name, cfg.Namespace)
@@ -157,7 +157,7 @@ func (f *fakeConfigController) update(t *testing.T, cfg config.Config) {
 func (f *fakeConfigController) delete(t *testing.T, kind config.GroupVersionKind, name, namespace string) {
 	t.Helper()
 	old := *f.Get(kind, name, namespace)
-	if err := f.ConfigStore.Delete(kind, name, namespace, nil); err != nil {
+	if err := f.Delete(kind, name, namespace, nil); err != nil {
 		t.Fatal(err)
 	}
 	for _, handler := range f.handlers[kind] {

--- a/dubbod/discovery/pkg/xds/endpoints/endpoint_builder_test.go
+++ b/dubbod/discovery/pkg/xds/endpoints/endpoint_builder_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package endpoints
 
 import (

--- a/dubbod/gui/handler.go
+++ b/dubbod/gui/handler.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gui
 
 import (

--- a/dubbod/gui/handler_test.go
+++ b/dubbod/gui/handler_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gui
 
 import (

--- a/dubbod/gui/resources/data/app.js
+++ b/dubbod/gui/resources/data/app.js
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Dubbo control plane console (Preact no-build).
  *

--- a/dubbod/gui/resources/data/charts.js
+++ b/dubbod/gui/resources/data/charts.js
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Hand-rolled SVG chart primitives (no external chart library).
  *

--- a/dubbod/gui/resources/data/index.html
+++ b/dubbod/gui/resources/data/index.html
@@ -1,3 +1,20 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/dubbod/gui/resources/data/mock.js
+++ b/dubbod/gui/resources/data/mock.js
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Development mock data.
  *

--- a/dubbod/gui/resources/data/styles.css
+++ b/dubbod/gui/resources/data/styles.css
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /* ---------------------------------------------------------------------------
  * Dubbo Console — "engineering print" design system
  *

--- a/dubbod/gui/resources/data/topology.js
+++ b/dubbod/gui/resources/data/topology.js
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Config-plane topology — the console's signature view.
  *

--- a/dubbod/gui/resources/fs.go
+++ b/dubbod/gui/resources/fs.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resources
 
 import (

--- a/pkg/kube/multicluster/eastwest.go
+++ b/pkg/kube/multicluster/eastwest.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package multicluster
 
 import (

--- a/pkg/kube/multicluster/eastwest_test.go
+++ b/pkg/kube/multicluster/eastwest_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package multicluster
 
 import (

--- a/pkg/kube/multicluster/secretcontroller_test.go
+++ b/pkg/kube/multicluster/secretcontroller_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package multicluster
 
 import (

--- a/samples/moviereview/src/details/Dockerfile
+++ b/samples/moviereview/src/details/Dockerfile
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM golang:1.25-alpine AS build
 
 WORKDIR /src

--- a/samples/moviereview/src/moviepage/Dockerfile
+++ b/samples/moviereview/src/moviepage/Dockerfile
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM python:3.12-alpine
 
 WORKDIR /app

--- a/samples/moviereview/src/ratings/Dockerfile
+++ b/samples/moviereview/src/ratings/Dockerfile
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM golang:1.25-alpine AS build
 
 WORKDIR /src

--- a/samples/moviereview/src/reviews-v1/Dockerfile
+++ b/samples/moviereview/src/reviews-v1/Dockerfile
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM eclipse-temurin:21-jdk-alpine AS build
 
 WORKDIR /src

--- a/samples/moviereview/src/reviews-v2/Dockerfile
+++ b/samples/moviereview/src/reviews-v2/Dockerfile
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM python:3.12-alpine
 
 WORKDIR /app

--- a/samples/moviereview/src/reviews-v3/Dockerfile
+++ b/samples/moviereview/src/reviews-v3/Dockerfile
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM node:22-alpine
 
 WORKDIR /app

--- a/tools/ci/install-helm.sh
+++ b/tools/ci/install-helm.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+version="${1:-}"
+if [[ ! "${version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "usage: $0 vMAJOR.MINOR.PATCH" >&2
+  exit 2
+fi
+
+case "$(uname -m)" in
+  x86_64) arch="amd64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+  *)
+    echo "unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "unsupported operating system: $(uname -s)" >&2
+  exit 1
+fi
+
+archive="helm-${version}-linux-${arch}.tar.gz"
+download_base="https://get.helm.sh"
+install_root="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/dubbo-ci-tools"
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/dubbo-helm.XXXXXX")"
+
+cleanup() {
+  rm -rf -- "${work_dir}"
+}
+trap cleanup EXIT
+
+curl -fsSLo "${work_dir}/${archive}" "${download_base}/${archive}"
+curl -fsSLo "${work_dir}/${archive}.sha256sum" "${download_base}/${archive}.sha256sum"
+expected="$(awk 'NR == 1 {print $1}' "${work_dir}/${archive}.sha256sum")"
+actual="$(sha256sum "${work_dir}/${archive}" | awk '{print $1}')"
+if [[ -z "${expected}" || "${actual}" != "${expected}" ]]; then
+  echo "helm checksum verification failed for ${archive}" >&2
+  exit 1
+fi
+
+tar -xzf "${work_dir}/${archive}" -C "${work_dir}"
+mkdir -p "${install_root}/bin"
+install -m 0755 "${work_dir}/linux-${arch}/helm" "${install_root}/bin/helm"
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  echo "${install_root}/bin" >> "${GITHUB_PATH}"
+fi
+
+"${install_root}/bin/helm" version --short

--- a/tools/ci/install-kind.sh
+++ b/tools/ci/install-kind.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+version="${1:-}"
+if [[ ! "${version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "usage: $0 vMAJOR.MINOR.PATCH" >&2
+  exit 2
+fi
+
+case "$(uname -m)" in
+  x86_64) arch="amd64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+  *)
+    echo "unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "unsupported operating system: $(uname -s)" >&2
+  exit 1
+fi
+
+binary="kind-linux-${arch}"
+download_base="https://github.com/kubernetes-sigs/kind/releases/download/${version}"
+install_root="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/dubbo-ci-tools"
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/dubbo-kind.XXXXXX")"
+
+cleanup() {
+  rm -rf -- "${work_dir}"
+}
+trap cleanup EXIT
+
+curl -fsSLo "${work_dir}/${binary}" "${download_base}/${binary}"
+curl -fsSLo "${work_dir}/${binary}.sha256sum" "${download_base}/${binary}.sha256sum"
+expected="$(awk 'NR == 1 {print $1}' "${work_dir}/${binary}.sha256sum")"
+actual="$(sha256sum "${work_dir}/${binary}" | awk '{print $1}')"
+if [[ -z "${expected}" || "${actual}" != "${expected}" ]]; then
+  echo "kind checksum verification failed for ${binary}" >&2
+  exit 1
+fi
+
+mkdir -p "${install_root}/bin"
+install -m 0755 "${work_dir}/${binary}" "${install_root}/bin/kind"
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  echo "${install_root}/bin" >> "${GITHUB_PATH}"
+fi
+
+"${install_root}/bin/kind" version

--- a/tools/govulncheck.py
+++ b/tools/govulncheck.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import json
 from pathlib import Path


### PR DESCRIPTION
## Summary

- replace disallowed Helm and kind Actions with checksum-verified repository scripts
- add a stable `CI Required` aggregate check and require it on `master` through `.asf.yaml`
- make Codecov upload failures blocking and keep the release chart job compatible with ASF Actions policy

## Root cause

GitHub rejected `azure/setup-helm` and `helm/kind-action` under the ASF enterprise Actions allowlist before any job could start.

## Verification

- `actionlint`
- `make lint-shell`
- `make lint-helm`
- `git diff --check`
- ASF `asfyaml-validate`
- Helm v3.16.4 and kind v0.30.0 installation in clean Debian Linux amd64 and arm64 containers

## Compatibility and rollout

The tool versions are unchanged. The new branch-protection context becomes effective after ASF applies `.asf.yaml`; `CI Required` fails unless all existing CI jobs succeed.