### PR TITLE
Fix Codecov authentication on protected branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: github.repository == 'apache/dubbo-kubernetes'
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -113,12 +116,13 @@ jobs:
           retention-days: 7
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.txt
+          files: ./coverage.txt
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: true
+          use_oidc: true
 
   performance:
     name: Performance Scale Smoke


### PR DESCRIPTION
## Summary
- authenticate Codecov uploads with GitHub OIDC
- grant `id-token: write` only to the unit-test job
- update the Codecov action to v5 and use the `files` input

## Context
The first protected `master` run failed with `Token required because branch is protected`. This keeps coverage upload blocking while removing the need for a repository upload token.

## Validation
- `actionlint .github/workflows/ci.yml`
- `git diff --check`