### PR TITLE
Stage solo maintainer review gate

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -42,3 +42,27 @@ github:
         contexts:
           # This stable aggregate check fails unless every required CI job passes.
           - CI Required
+  rulesets:
+    # Stage the review policy on an isolated branch before targeting master.
+    - name: "Solo Maintainer Review Gate"
+      target: branch
+      enforcement: active
+      bypass_actors:
+        - actor_id: 91593982
+          actor_type: User
+          bypass_mode: pull_request
+      conditions:
+        ref_name:
+          include:
+            - "refs/heads/policy/ruleset-sandbox"
+          exclude: []
+      rules:
+        - type: deletion
+        - type: non_fast_forward
+        - type: pull_request
+          parameters:
+            dismiss_stale_reviews_on_push: true
+            require_code_owner_review: true
+            require_last_push_approval: false
+            required_approving_review_count: 1
+            required_review_thread_resolution: true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,12 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# OWNERS drives the /lgtm merge command in .github/workflows/commands.yml.
-# GitHub CODEOWNERS and the repository rulesets independently enforce the
-# required maintainer review before another user's pull request can merge.
-
-approvers:
-  - mfordjody
-
-reviewers:
-  - mfordjody
+* @mfordjody

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -20,8 +20,9 @@
 #   /unassign [@user ...]  remove assignees
 #   /lgtm                  (PR only, write access, not the PR author) label the
 #                          PR with `lgtm`; if the commenter is an approver in
-#                          the root OWNERS file, the PR is squash-merged (or
-#                          auto-merge is enabled while checks are running) —
+#                          the root OWNERS file, request a squash merge (or
+#                          auto-merge while checks run). Repository rulesets
+#                          still enforce CI and required Code Owner review;
 #                          non-approvers only apply the label
 #   /lgtm cancel           remove the `lgtm` label and disable auto-merge
 #   /close                 close the issue/PR (author or write access)


### PR DESCRIPTION
## Summary
- make `@mfordjody` the global GitHub Code Owner
- stage a ruleset requiring one Code Owner approval on `policy/ruleset-sandbox`
- allow only user ID `91593982` to bypass the review rule through a pull request
- clarify that `/lgtm` remains subject to repository CI and review rules

## Safety
This first phase does not target `master`. After ASF creates the sandbox ruleset, its behavior will be verified before activation on the default branch.

## Validation
- official `asfyaml-validate --repo . --org apache`
- `actionlint .github/workflows/commands.yml`
- `git diff --check`