### PR TITLE
Enable ASF ruleset reconciliation

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+meta:
+  # ASF currently gates repository ruleset reconciliation behind this rollout.
+  environment: github_rulesets
+
 notifications:
     commits:      commits@dubbo.apache.org
     issues:       notifications@dubbo.apache.org


### PR DESCRIPTION
## Summary
- opt this repository into the ASF `github_rulesets` rollout environment
- activate reconciliation for the already-staged sandbox Review Gate

Without this metadata, the deployed ASF processor accepts the schema but skips the ruleset directive, leaving the repository ruleset list empty.

## Validation
- official `asfyaml-validate --repo . --org apache`
- `git diff --check`