### PR TITLE
Enable next-generation ASF YAML processing

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,6 +16,7 @@
 meta:
   # ASF currently gates repository ruleset reconciliation behind this rollout.
   environment: github_rulesets
+  nextgen: true
 
 notifications:
     commits:      commits@dubbo.apache.org


### PR DESCRIPTION
## Summary
- route `.asf.yaml` through ASF next-generation processing
- allow the `github_rulesets` rollout environment to reconcile the staged Review Gate

The rollout environment alone remained a no-op in this repository. Active ASF ruleset users, including `apache/texera`, enable both `environment: github_rulesets` and `nextgen: true`.

## Validation
- official `asfyaml-validate --repo . --org apache`
- `git diff --check`