### PR TITLE
Require maintainer approval on master

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -44,5 +44,5 @@ github:
           # forge either required result.
           - context: CI Required
             app_id: 15368
-          - context: Maintainer Approval
+          - context: Maintainer Approval Gate
             app_id: 15368

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,6 +39,10 @@ github:
     master:
       required_status_checks:
         strict: true
-        contexts:
-          # This stable aggregate check fails unless every required CI job passes.
-          - CI Required
+        checks:
+          # Pin both gates to the GitHub Actions App so a personal token cannot
+          # forge either required result.
+          - context: CI Required
+            app_id: 15368
+          - context: Maintainer Approval
+            app_id: 15368

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -94,7 +94,7 @@ jobs:
               repo,
               sha: pr.head.sha,
               state: match[1] && !authorIsMaintainer ? 'pending' : 'success',
-              context: 'Maintainer Approval',
+              context: 'Maintainer Approval Gate',
               description: match[1] && !authorIsMaintainer
                 ? 'Maintainer approval cancelled'
                 : 'Approved by @mfordjody via /lgtm',

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -43,7 +43,7 @@ permissions:
 
 jobs:
   approval:
-    name: Maintainer Approval
+    name: Publish Maintainer Approval
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: |
@@ -63,7 +63,7 @@ jobs:
                 repo,
                 sha,
                 state,
-                context: 'Maintainer Approval',
+                context: 'Maintainer Approval Gate',
                 description,
                 target_url: targetUrl,
               });


### PR DESCRIPTION
## Summary
- require `Maintainer Approval` alongside `CI Required` on `master`
- pin both required results to GitHub Actions App ID `15368`
- prevent personal tokens or unrelated integrations from forging either gate

The approval workflow is already active on `master` and has successfully published the expected App-owned status.

## Validation
- official `asfyaml-validate --repo . --org apache`
- `git diff --check`