### PR TITLE
Fix maintainer review detection

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -92,17 +92,19 @@ jobs:
             const authorIsMaintainer = pr.user.login.toLowerCase() === maintainer;
             let approved = authorIsMaintainer;
             if (!approved) {
-              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              const reviews = await github.paginate('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
                 owner,
                 repo,
                 pull_number: pr.number,
                 per_page: 100,
               });
-              approved = reviews.some((review) =>
-                review.user?.login.toLowerCase() === maintainer &&
-                review.state === 'APPROVED' &&
+              const currentApprovals = reviews.filter((review) =>
+                review.user?.login?.toLowerCase() === maintainer &&
+                String(review.state).toUpperCase() === 'APPROVED' &&
                 review.commit_id === pr.head.sha,
               );
+              core.info(`Found ${currentApprovals.length} current approval(s) from @${maintainer} among ${reviews.length} review(s)`);
+              approved = currentApprovals.length > 0;
             }
 
             await publish(


### PR DESCRIPTION
## Summary
- enumerate pull request reviews through an explicit paginated REST route
- normalize optional reviewer/state fields before matching
- log review and current-approval counts for auditability

## Validation
- `actionlint .github/workflows/review-gate.yml`
- `git diff --check`

This fixes the observed case where PR #945 had an `APPROVED` review from `@mfordjody` on the current SHA but a manual recomputation still emitted a pending gate.