### PR TITLE
Fix release workflow action policy

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -177,56 +177,86 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.2.0
-
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.2.0
+        run: |
+          BUILDER="release-builder-${GITHUB_RUN_ID}"
+          docker buildx create \
+            --name "${BUILDER}" \
+            --driver docker-container \
+            --use \
+            --bootstrap
+          echo "BUILDER=${BUILDER}" >> "${GITHUB_ENV}"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${GH_TOKEN}" | docker login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
 
       - name: Build and push versioned image
         id: build_image
-        uses: docker/build-push-action@v7.3.0
-        with:
-          context: .
-          file: dubbod/discovery/docker/dockerfile.dubbod
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ env.IMAGE }}:${{ github.ref_name }}
-          labels: |
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ github.ref_name }}
-          build-args: |
-            GIT_VERSION=${{ github.ref_name }}
-          provenance: mode=max
-          sbom: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        env:
+          TAG: ${{ github.ref_name }}
+          REVISION: ${{ github.sha }}
+        run: |
+          METADATA="${RUNNER_TEMP}/build-metadata.json"
+          docker buildx build \
+            --builder "${BUILDER}" \
+            --file dubbod/discovery/docker/dockerfile.dubbod \
+            --platform linux/amd64,linux/arm64 \
+            --push \
+            --tag "${IMAGE}:${TAG}" \
+            --label "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
+            --label "org.opencontainers.image.revision=${REVISION}" \
+            --label "org.opencontainers.image.version=${TAG}" \
+            --build-arg "GIT_VERSION=${TAG}" \
+            --provenance=mode=max \
+            --sbom=true \
+            --metadata-file "${METADATA}" \
+            .
+
+          DIGEST=$(jq -r '."containerimage.digest" // empty' "${METADATA}")
+          if [[ ! "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Docker Buildx did not return a valid image digest: ${DIGEST}" >&2
+            exit 1
+          fi
+          echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        env:
+          COSIGN_VERSION: v3.0.6
+          COSIGN_SHA256: c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74
+        run: |
+          COSIGN="${RUNNER_TEMP}/cosign"
+          curl --retry 3 --fail --silent --show-error --location \
+            "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" \
+            --output "${COSIGN}"
+          echo "${COSIGN_SHA256}  ${COSIGN}" | sha256sum --check
+          chmod +x "${COSIGN}"
+          echo "COSIGN=${COSIGN}" >> "${GITHUB_ENV}"
 
       - name: Sign image digest with GitHub OIDC
         env:
           DIGEST: ${{ steps.build_image.outputs.digest }}
-        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+        run: |
+          "${COSIGN}" sign --yes "${IMAGE}@${DIGEST}"
 
       - name: Verify image signature
         env:
           DIGEST: ${{ steps.build_image.outputs.digest }}
           CERTIFICATE_IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/release.yaml@${{ github.ref }}
         run: |
-          cosign verify \
+          "${COSIGN}" verify \
             --certificate-identity "${CERTIFICATE_IDENTITY}" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             "${IMAGE}@${DIGEST}"
+
+      - name: Clean up container registry session and builder
+        if: always()
+        run: |
+          docker logout ghcr.io || true
+          if [ -n "${BUILDER:-}" ]; then
+            docker buildx rm "${BUILDER}" || true
+          fi
 
   package_charts:
     name: Package Helm Charts

--- a/dubbod/discovery/docker/dockerfile.dubbod
+++ b/dubbod/discovery/docker/dockerfile.dubbod
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
## What is this PR for?

Replace release-time third-party Actions that are blocked by the Apache organization policy with equivalent Docker Buildx and Cosign CLI commands. Build the multi-architecture image through native Go cross-compilation so QEMU is not required.

## What type of PR is it?

Bug Fix

## What is the Jira issue?

N/A

## How should this be tested?

- `actionlint .github/workflows/release.yaml`
- local `docker buildx build --platform linux/amd64,linux/arm64 ...`
- rerun the `0.4.4` release after merge