### PR TITLE
fix: add ASF headers to AI mesh fixture

### DIFF
--- a/tests/e2e/agentmock/Dockerfile
+++ b/tests/e2e/agentmock/Dockerfile
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM golang:1.25-alpine AS builder
 WORKDIR /src
 COPY main.go .

--- a/tests/e2e/agentmock/main.go
+++ b/tests/e2e/agentmock/main.go
@@ -1,7 +1,17 @@
 // Licensed to the Apache Software Foundation (ASF) under one or more
-// contributor license agreements. See the NOTICE file distributed with
+// contributor license agreements.  See the NOTICE file distributed with
 // this work for additional information regarding copyright ownership.
-// The ASF licenses this file to You under the Apache License, Version 2.0.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package main
 


### PR DESCRIPTION
Fix the only failed check from #1007: SkyWalking Eyes reported both new `agentmock` files without valid ASF headers.

Verification:
- headers now match the repository ASF template
- `go test ./tests/e2e/agentmock`
- `git diff --check`